### PR TITLE
Replace ... by … (ellipsis symbol)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ This project is very much in-progress and has a lot of remaining work. Here is a
 - [ ] Integrate with the OS notifications
 - [ ] Audio notification when a message is received
 - [ ] Add server/channel history even when a connection is closed so that you can open from history in the welcome view
-- [ ] Use the display name given by the IRC server when connecting (NETWORK=...)
+- [ ] Use the display name given by the IRC server when connecting (NETWORK=…)
 - [ ] Associate `irc://` links to open in-app
 - [ ] Support downloading files from channels ([#4](https://github.com/avojak/iridium/issues/4))
 

--- a/meson/post_install.py
+++ b/meson/post_install.py
@@ -7,13 +7,13 @@ install_prefix = os.environ['MESON_INSTALL_PREFIX']
 schema_dir = os.path.join(install_prefix, 'share/glib-2.0/schemas')
 
 if not os.environ.get('DESTDIR'):
-    print('Compiling gsettings schemas...')
+    print('Compiling gsettings schemas…')
     subprocess.call(['glib-compile-schemas', schema_dir])
 
-    print('Updating icon cache...')
+    print('Updating icon cache…')
     icon_cache_dir = os.path.join(install_prefix, 'share/icons/hicolor')
     subprocess.call(['gtk-update-icon-cache', '-qtf', icon_cache_dir])
 
-    print('Updating desktop database...')
+    print('Updating desktop database…')
     desktop_database_dir = os.path.join(install_prefix, 'share/applications')
     subprocess.call(['update-desktop-database', '-q', desktop_database_dir])

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -237,7 +237,7 @@ public class Iridium.MainWindow : Gtk.ApplicationWindow {
             // to closing the application.
             side_panel.server_row_disabled.disconnect (Iridium.Application.connection_dao.on_server_row_disabled);
 
-            // TODO: Not sure if this is right...
+            // TODO: Not sure if this is right…
             connection_handler.close_all_connections ();
             GLib.Process.exit (0);
         });

--- a/src/Models/PrivateMessageText.vala
+++ b/src/Models/PrivateMessageText.vala
@@ -42,7 +42,7 @@ public abstract class Iridium.Models.PrivateMessageText : Iridium.Models.RichTex
             username = string.nfill (USERNAME_SPACING, ' ');
         } else if (username.length > USERNAME_SPACING) {
             username = username.substring (0, USERNAME_SPACING - 3);
-            username += "...";
+            username += "…";
         } else {
             username += string.nfill (USERNAME_SPACING - username.length, ' ');
         }

--- a/src/Services/ServerConnectionDAO.vala
+++ b/src/Services/ServerConnectionDAO.vala
@@ -38,7 +38,7 @@ public class Iridium.Services.ServerConnectionDAO : GLib.Object {
     }
 
     public void on_server_row_added (string server_name) {
-        // TODO: Implement - maybe do nothing...?
+        // TODO: Implement - maybe do nothing…?
     }
 
     public void on_server_row_removed (string server_name) {

--- a/src/Views/ChannelChatView.vala
+++ b/src/Views/ChannelChatView.vala
@@ -62,7 +62,7 @@ public class Iridium.Views.ChannelChatView : Iridium.Views.ChatView {
         edit_button.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
         edit_button.relief = Gtk.ReliefStyle.NONE;
         edit_button.valign = Gtk.Align.CENTER;
-        edit_button.set_tooltip_text ("Edit topic...");
+        edit_button.set_tooltip_text ("Edit topic…");
         edit_button.clicked.connect (() => {
             show_topic_edit_dialog ();
         });

--- a/src/Views/ChatView.vala
+++ b/src/Views/ChatView.vala
@@ -215,9 +215,9 @@ public abstract class Iridium.Views.ChatView : Gtk.Grid {
         text_view.get_buffer ().remove_tag_by_name ("selectable-underline", buffer_start, buffer_end);
     }
 
-    // TODO: Need to figure out a good way to lock scrolling... Might be annoying
+    // TODO: Need to figure out a good way to lock scrolling… Might be annoying
     //       to experience the auto-scroll when you're looking back at old
-    //       messages...
+    //       messages…
     protected void do_autoscroll () {
         var buffer_end_mark = text_view.get_buffer ().get_mark ("buffer-end");
         if (buffer_end_mark != null) {

--- a/src/Widgets/NetworkInfoBar.vala
+++ b/src/Widgets/NetworkInfoBar.vala
@@ -35,7 +35,7 @@ public class Iridium.Widgets.NetworkInfoBar : Gtk.InfoBar {
         var network_info_label = new Gtk.Label ("Network is not available");
         get_content_area ().add (network_info_label);
         get_style_context ().add_class ("inline");
-        add_button ("Network Settings...", 0);
+        add_button ("Network Settings…", 0);
 
         this.response.connect ((response) => {
             if (response == 0) {

--- a/src/Widgets/SidePanel/Panel.vala
+++ b/src/Widgets/SidePanel/Panel.vala
@@ -261,7 +261,7 @@ public class Iridium.Widgets.SidePanel.Panel : Granite.Widgets.SourceList {
         if (selected.name == "") {
             return null;
         }
-        // TODO: This feels wrong...
+        // TODO: This feels wrong…
         unowned Iridium.Widgets.SidePanel.Row row = (Iridium.Widgets.SidePanel.Row) selected;
         return row.get_server_name ();
     }

--- a/src/Widgets/SidePanel/ServerRow.vala
+++ b/src/Widgets/SidePanel/ServerRow.vala
@@ -101,7 +101,7 @@ public class Iridium.Widgets.SidePanel.ServerRow : Granite.Widgets.SourceList.Ex
     public override Gtk.Menu? get_context_menu () {
         var menu = new Gtk.Menu ();
 
-        var join_item = new Gtk.MenuItem.with_label ("Join a Channel...");
+        var join_item = new Gtk.MenuItem.with_label ("Join a Channel…");
         join_item.activate.connect (() => {
             join_channel ();
         });

--- a/src/Widgets/StatusBar.vala
+++ b/src/Widgets/StatusBar.vala
@@ -24,8 +24,8 @@ public class Iridium.Widgets.StatusBar : Gtk.ActionBar {
     private Gtk.MenuItem channel_join_menu_item;
 
     construct {
-        var server_connect_menu_item = new Gtk.MenuItem.with_label ("Connect to a Server...");
-        channel_join_menu_item = new Gtk.MenuItem.with_label ("Join a Channel...");
+        var server_connect_menu_item = new Gtk.MenuItem.with_label ("Connect to a Server…");
+        channel_join_menu_item = new Gtk.MenuItem.with_label ("Join a Channel…");
         
         var menu = new Gtk.Menu ();
         menu.append (server_connect_menu_item);


### PR DESCRIPTION
You have to use the ellipsis symbol instead of three detached dots according to the [elementary Human Interface Guidelines](https://elementary.io/fr/docs/human-interface-guidelines#using-ellipses).

**This PR is ready for review**