### PR TITLE
Fix build against valac 0.46.* or later

### DIFF
--- a/src/Models/PrivateMessageText.vala
+++ b/src/Models/PrivateMessageText.vala
@@ -25,7 +25,7 @@ public abstract class Iridium.Models.PrivateMessageText : Iridium.Models.RichTex
 
     public bool suppress_sender_username { get; set; }
 
-    public PrivateMessageText (Iridium.Services.Message message) {
+    protected PrivateMessageText (Iridium.Services.Message message) {
         Object (
             message: message,
             suppress_sender_username: false

--- a/src/Models/RichText.vala
+++ b/src/Models/RichText.vala
@@ -30,7 +30,7 @@ public abstract class Iridium.Models.RichText : GLib.Object {
     //  private string self_username;
     private Gee.List<string> usernames = new Gee.ArrayList<string> ();
 
-    public RichText (Iridium.Services.Message message) {
+    protected RichText (Iridium.Services.Message message) {
         Object (
             message: message
         );

--- a/src/Views/ChatView.vala
+++ b/src/Views/ChatView.vala
@@ -40,7 +40,7 @@ public abstract class Iridium.Views.ChatView : Gtk.Grid {
     private Gdk.Cursor cursor_pointer;
     private Gdk.Cursor cursor_text;
 
-    public ChatView () {
+    protected ChatView () {
         Object (
             orientation: Gtk.Orientation.VERTICAL
         );


### PR DESCRIPTION
```
../src/Models/RichText.vala:33.5-33.19: error: Creation method of abstract class cannot be public.
    public RichText (Iridium.Services.Message message) {
    ^^^^^^^^^^^^^^^
../src/Models/PrivateMessageText.vala:28.5-28.29: error: Creation method of abstract class cannot be public.
    public PrivateMessageText (Iridium.Services.Message message) {
    ^^^^^^^^^^^^^^^^^^^^^^^^^
../src/Views/ChatView.vala:43.5-43.19: error: Creation method of abstract class cannot be public.
    public ChatView () {
    ^^^^^^^^^^^^^^^
Compilation failed: 3 error(s), 0 warning(s)
```
