### PR TITLE
Warn before closing a connection

### DIFF
--- a/data/com.github.avojak.iridium.gschema.xml.in
+++ b/data/com.github.avojak.iridium.gschema.xml.in
@@ -21,5 +21,10 @@
       <summary>The default real name when connecting to a server</summary>
       <description>The default real name when connecting to a server</description>
     </key>
+    <key name="suppress-connection-close-warnings" type="b">
+      <default>false</default>
+      <summary>If warnings should be suppressed when closing a server connection</summary>
+      <description>If warnings should be suppressed when closing a server connection</description>
+    </key>
   </schema>
 </schemalist>

--- a/src/Widgets/SidePanel/ServerRow.vala
+++ b/src/Widgets/SidePanel/ServerRow.vala
@@ -165,9 +165,9 @@ public class Iridium.Widgets.SidePanel.ServerRow : Granite.Widgets.SourceList.Ex
             disconnect_from_server ();
         });
 
-        var close_item = new Gtk.MenuItem.with_label (_("Close"));
-        close_item.activate.connect (() => {
-            if (warn_before_close ()) {
+        var remove_item = new Gtk.MenuItem.with_label (_("Remove"));
+        remove_item.activate.connect (() => {
+            if (warn_before_remove ()) {
                 if (get_enabled ()) {
                     disconnect_from_server ();
                 }
@@ -182,14 +182,14 @@ public class Iridium.Widgets.SidePanel.ServerRow : Granite.Widgets.SourceList.Ex
         } else {
             menu.append (connect_item);
         }
-        menu.append (close_item);
+        menu.append (remove_item);
 
         menu.show_all ();
 
         return menu;
     }
 
-    private bool warn_before_close () {
+    private bool warn_before_remove () {
         // First check the settings to see if the user has already opted to not be warned
         if (Iridium.Application.settings.get_boolean ("suppress-connection-close-warnings")) {
             return true;
@@ -198,12 +198,12 @@ public class Iridium.Widgets.SidePanel.ServerRow : Granite.Widgets.SourceList.Ex
         bool should_close = false;
         var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
             _("Are you sure you want to proceed?"),
-            _("By closing this connection you won’t be able to recover the connection settings."),
+            _("By removing this connection will be disconnected, and you won’t be able to recover the connection settings. If you wish to join this server again in the future, you will need to re-enter the connection settings."),
             "dialog-warning",
             Gtk.ButtonsType.CANCEL);
         message_dialog.transient_for = window;
 
-        var suggested_button = new Gtk.Button.with_label (_("Yes, disconnect"));
+        var suggested_button = new Gtk.Button.with_label (_("Yes, remove"));
         suggested_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
         message_dialog.add_action_widget (suggested_button, Gtk.ResponseType.ACCEPT);
 

--- a/src/Widgets/SidePanel/ServerRow.vala
+++ b/src/Widgets/SidePanel/ServerRow.vala
@@ -198,7 +198,7 @@ public class Iridium.Widgets.SidePanel.ServerRow : Granite.Widgets.SourceList.Ex
         bool should_close = false;
         var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
             _("Are you sure you want to proceed?"),
-            _("By removing this connection will be disconnected, and you won’t be able to recover the connection settings. If you wish to join this server again in the future, you will need to re-enter the connection settings."),
+            _("By removing this connection you will be disconnected, and will not be able to recover the connection settings. If you wish to join this server again in the future, you will need to re-enter the connection settings."),
             "dialog-warning",
             Gtk.ButtonsType.CANCEL);
         message_dialog.transient_for = window;


### PR DESCRIPTION
Adds a warning dialog when closing a connection because connection details are erased upon closure. The warning can be suppressed via a checkbox connected to the application settings.