### PR TITLE
Fix views not being disabled appropriately

### DIFF
--- a/src/Views/PrivateMessageChatView.vala
+++ b/src/Views/PrivateMessageChatView.vala
@@ -38,7 +38,7 @@ public class Iridium.Views.PrivateMessageChatView : Iridium.Views.ChatView {
     }
 
     protected override string get_disabled_message () {
-        return ""; // TODO: Does this even make sense since we don't allow disabled PM items?
+        return _("You are not connected to this server");
     }
 
     public override void do_display_self_private_msg (Iridium.Services.Message message) {

--- a/src/Widgets/SidePanel/Panel.vala
+++ b/src/Widgets/SidePanel/Panel.vala
@@ -322,6 +322,10 @@ public class Iridium.Widgets.SidePanel.Panel : Gtk.Grid {
         }
         unowned Iridium.Widgets.SidePanel.Row row = (Iridium.Widgets.SidePanel.Row) server_item;
         row.enable ();
+        // Private message rows are directly tied to the server row
+        foreach (var private_message_row in private_message_items.get (server_name)) {
+            private_message_row.enable ();
+        }
         server_row_enabled (server_name);
     }
 
@@ -335,6 +339,9 @@ public class Iridium.Widgets.SidePanel.Panel : Gtk.Grid {
         // Disable all of the children
         foreach (var channel_row in channel_items.get (server_name)) {
             channel_row.disable ();
+        }
+        foreach (var private_message_row in private_message_items.get (server_name)) {
+            private_message_row.disable ();
         }
         server_row_disabled (server_name);
     }


### PR DESCRIPTION
Fixes #71 and #77 

- Chat views are disabled when server connection is closed
- Chat views are disabled when network connection is lost
- Private message views are disabled when server connection is closed
- Private message views are automatically re-enabled when server connection is opened, because they do not have a concept of needing to join them in addition to simply being connected to the server