### PR TITLE
Update usage of username vs. nickname

### DIFF
--- a/src/Models/Message.vala
+++ b/src/Models/Message.vala
@@ -42,7 +42,7 @@ public class Iridium.Services.Message : GLib.Object {
     public string message { get; set; }
     public string prefix { get; set; }
     public string[] params { get; set; }
-    public string username { get; set; }
+    public string nickname { get; set; }
 
     static construct {
         try {
@@ -78,7 +78,7 @@ public class Iridium.Services.Message : GLib.Object {
                     strip_non_printable_chars ();
                 }
                 if ((prefix != null) && (command in USER_COMMANDS)) {  // vala-lint=naming-convention
-                    username = prefix.split ("!")[0];
+                    nickname = prefix.split ("!")[0];
                 }
                 return false;
             });

--- a/src/Models/Text/OthersPrivateMessageText.vala
+++ b/src/Models/Text/OthersPrivateMessageText.vala
@@ -28,7 +28,7 @@ public class Iridium.Models.Text.OthersPrivateMessageText : Iridium.Models.Text.
     }
 
     public override string get_tag_name () {
-        return "username";
+        return "nickname";
     }
 
 }

--- a/src/Models/Text/PrivateMessageText.vala
+++ b/src/Models/Text/PrivateMessageText.vala
@@ -21,14 +21,14 @@
 
 public abstract class Iridium.Models.Text.PrivateMessageText : Iridium.Models.Text.RichText {
 
-    private static uint16 USERNAME_SPACING = 20; // vala-lint=naming-convention
+    private static uint16 NICKNAME_SPACING = 20; // vala-lint=naming-convention
 
-    public bool suppress_sender_username { get; set; }
+    public bool suppress_sender_nickname { get; set; }
 
     protected PrivateMessageText (Iridium.Services.Message message) {
         Object (
             message: message,
-            suppress_sender_username: false
+            suppress_sender_nickname: false
         );
     }
 
@@ -36,25 +36,25 @@ public abstract class Iridium.Models.Text.PrivateMessageText : Iridium.Models.Te
         Gtk.TextIter iter;
         buffer.get_end_iter (out iter);
 
-        // Display username
-        var username = message.username;
-        if (suppress_sender_username) {
-            username = string.nfill (USERNAME_SPACING, ' ');
-        } else if (username.length > USERNAME_SPACING) {
-            username = username.substring (0, USERNAME_SPACING - 3);
-            username += "…";
+        // Display nickname
+        var nickname = message.nickname;
+        if (suppress_sender_nickname) {
+            nickname = string.nfill (NICKNAME_SPACING, ' ');
+        } else if (nickname.length > NICKNAME_SPACING) {
+            nickname = nickname.substring (0, NICKNAME_SPACING - 3);
+            nickname += "…";
         } else {
-            username += string.nfill (USERNAME_SPACING - username.length, ' ');
+            nickname += string.nfill (NICKNAME_SPACING - nickname.length, ' ');
         }
-        buffer.insert (ref iter, username, username.length);
+        buffer.insert (ref iter, nickname, nickname.length);
 
-        // Format the username
-        Gtk.TextIter username_start = iter;
-        username_start.backward_chars (username.length);
-        Gtk.TextIter username_end = username_start;
-        username_end.forward_chars (message.username.length);
-        buffer.apply_tag_by_name (get_tag_name (), username_start, username_end);
-        buffer.apply_tag_by_name ("selectable", username_start, username_end);
+        // Format the nickname
+        Gtk.TextIter nickname_start = iter;
+        nickname_start.backward_chars (nickname.length);
+        Gtk.TextIter nickname_end = nickname_start;
+        nickname_end.forward_chars (message.nickname.length);
+        buffer.apply_tag_by_name (get_tag_name (), nickname_start, nickname_end);
+        buffer.apply_tag_by_name ("selectable", nickname_start, nickname_end);
         buffer.insert (ref iter, message.message, message.message.length);
         buffer.insert (ref iter, "\n", 1);
     }

--- a/src/Models/Text/RichText.vala
+++ b/src/Models/Text/RichText.vala
@@ -27,8 +27,8 @@ public abstract class Iridium.Models.Text.RichText : GLib.Object {
 
     public Iridium.Services.Message message { get; construct; }
 
-    //  private string self_username;
-    private Gee.List<string> usernames = new Gee.ArrayList<string> ();
+    //  private string self_nickname;
+    private Gee.List<string> nicknames = new Gee.ArrayList<string> ();
 
     protected RichText (Iridium.Services.Message message) {
         Object (
@@ -46,23 +46,23 @@ public abstract class Iridium.Models.Text.RichText : GLib.Object {
         }
     }
 
-    // Set our username so we can check for it and apply different styling
-    //  public void set_username (string username) {
-    //      this.self_username = username;
+    // Set our nickname so we can check for it and apply different styling
+    //  public void set_nickname (string nickname) {
+    //      this.self_nickname = nickname;
     //  }
 
-    // Set the usernames that will be checked for to apply different styling
-    public void set_usernames (Gee.List<string> usernames) {
-        this.usernames = usernames;
+    // Set the nicknames that will be checked for to apply different styling
+    public void set_nicknames (Gee.List<string> nicknames) {
+        this.nicknames = nicknames;
     }
 
     public void display (Gtk.TextBuffer buffer) {
         // Display the rich text in the buffer
         do_display (buffer);
 
-        // Apply tags for usernames first (this prevents 'username:' being picked up
+        // Apply tags for nicknames first (this prevents 'nickname:' being picked up
         // as a URI)
-        apply_username_tags (buffer);
+        apply_nickname_tags (buffer);
 
         // Apply tag for URIs
         apply_uri_tags (buffer);
@@ -100,7 +100,7 @@ public abstract class Iridium.Models.Text.RichText : GLib.Object {
         foreach (string token in tokens) {
             if (URI_REGEX.match (token)) {
                 iter = search_start;
-                // Make sure we're not trying to tag something that's already selectable (i.e. a username)
+                // Make sure we're not trying to tag something that's already selectable (i.e. a nickname)
                 if (iter.has_tag (selectable_tag)) {
                     continue;
                 }
@@ -113,37 +113,37 @@ public abstract class Iridium.Models.Text.RichText : GLib.Object {
         }
     }
 
-    private void apply_username_tags (Gtk.TextBuffer buffer) {
+    private void apply_nickname_tags (Gtk.TextBuffer buffer) {
         Gtk.TextIter search_start;
         Gtk.TextIter search_end;
         Gtk.TextIter match_start;
         Gtk.TextIter match_end;
-        foreach (var username in usernames) {
+        foreach (var nickname in nicknames) {
             // Set start_iter and end_iter for the portion of the buffer with the new message
             buffer.get_end_iter (out search_start);
             search_start.backward_chars (message.message.length + 1); // +1 for newline char
             buffer.get_end_iter (out search_end);
             search_end.backward_chars (1);
 
-            while (search_start.forward_search (username, Gtk.TextSearchFlags.CASE_INSENSITIVE, out match_start, out match_end, search_end)) {
+            while (search_start.forward_search (nickname, Gtk.TextSearchFlags.CASE_INSENSITIVE, out match_start, out match_end, search_end)) {
                 if (match_start.starts_word () && match_end.ends_word ()) {
-                    buffer.apply_tag_by_name ("inline-username", match_start, match_end);
+                    buffer.apply_tag_by_name ("inline-nickname", match_start, match_end);
                     buffer.apply_tag_by_name ("selectable", match_start, match_end);
                 }
                 search_start = match_end;
             }
         }
 
-        // TODO: Check for our username and style the whole message
+        // TODO: Check for our nickname and style the whole message
         //  // Reset the search iters
         //  buffer.get_end_iter (out search_start);
         //  search_start.backward_chars (message.message.length + 1); // +1 for newline char
         //  buffer.get_end_iter (out search_end);
         //  search_end.backward_chars (1);
 
-        //  // The our username appears, color the whole message
-        //  if (search_start.forward_search (self_username, Gtk.TextSearchFlags.CASE_INSENSITIVE, out match_start, out match_end, search_end)) {
-        //      buffer.apply_tag_by_name ("inline-self-username", search_start, search_end);
+        //  // The our nickname appears, color the whole message
+        //  if (search_start.forward_search (self_nickname, Gtk.TextSearchFlags.CASE_INSENSITIVE, out match_start, out match_end, search_end)) {
+        //      buffer.apply_tag_by_name ("inline-self-nickname", search_start, search_end);
         //  }
     }
 

--- a/src/Models/Text/SelfPrivateMessageText.vala
+++ b/src/Models/Text/SelfPrivateMessageText.vala
@@ -28,7 +28,7 @@ public class Iridium.Models.Text.SelfPrivateMessageText : Iridium.Models.Text.Pr
     }
 
     public override string get_tag_name () {
-        return "self-username";
+        return "self-nickname";
     }
 
 }

--- a/src/Services/ServerConnectionManager.vala
+++ b/src/Services/ServerConnectionManager.vala
@@ -237,8 +237,8 @@ public class Iridium.Services.ServerConnectionManager : GLib.Object {
         server_quit (source.connection_details.server, message);
     }
 
-    private void on_user_quit_server (Iridium.Services.ServerConnection source, string username, Gee.List<string> channels, Iridium.Services.Message message) {
-        user_quit_server (source.connection_details.server, username, channels, message);
+    private void on_user_quit_server (Iridium.Services.ServerConnection source, string nickname, Gee.List<string> channels, Iridium.Services.Message message) {
+        user_quit_server (source.connection_details.server, nickname, channels, message);
     }
 
     private void on_channel_users_received (Iridium.Services.ServerConnection source, string channel_name) {
@@ -269,16 +269,16 @@ public class Iridium.Services.ServerConnectionManager : GLib.Object {
         channel_message_received (source.connection_details.server, channel_name, message);
     }
 
-    private void on_user_joined_channel (Iridium.Services.ServerConnection source, string channel_name, string username) {
-        user_joined_channel (source.connection_details.server, channel_name, username);
+    private void on_user_joined_channel (Iridium.Services.ServerConnection source, string channel_name, string nickname) {
+        user_joined_channel (source.connection_details.server, channel_name, nickname);
     }
 
-    private void on_user_left_channel (Iridium.Services.ServerConnection source, string channel_name, string username) {
-        user_left_channel (source.connection_details.server, channel_name, username);
+    private void on_user_left_channel (Iridium.Services.ServerConnection source, string channel_name, string nickname) {
+        user_left_channel (source.connection_details.server, channel_name, nickname);
     }
 
-    private void on_private_message_received (Iridium.Services.ServerConnection source, string username, string self_nickname, Iridium.Services.Message message) {
-        private_message_received (source.connection_details.server, username, self_nickname, message);
+    private void on_private_message_received (Iridium.Services.ServerConnection source, string nickname, string self_nickname, Iridium.Services.Message message) {
+        private_message_received (source.connection_details.server, nickname, self_nickname, message);
     }
 
     private void on_insufficient_privs_received (Iridium.Services.ServerConnection source, string channel_name, Iridium.Services.Message message) {
@@ -308,7 +308,7 @@ public class Iridium.Services.ServerConnectionManager : GLib.Object {
     public signal void server_message_received (string server_name, Iridium.Services.Message message);
     public signal void server_error_received (string server_name, Iridium.Services.Message message);
     public signal void server_quit (string server_name, string message);
-    public signal void user_quit_server (string server_name, string username, Gee.List<string> channels, Iridium.Services.Message message);
+    public signal void user_quit_server (string server_name, string nickname, Gee.List<string> channels, Iridium.Services.Message message);
     public signal void channel_users_received (string server_name, string channel_name);
     public signal void channel_topic_received (string server_name, string channel_name);
     public signal void nickname_in_use (string server_name, Iridium.Services.Message message);
@@ -316,9 +316,9 @@ public class Iridium.Services.ServerConnectionManager : GLib.Object {
     public signal void channel_joined (string server_name, string channel_name, string nickname);
     public signal void channel_left (string server_name, string channel_name);
     public signal void channel_message_received (string server_name, string channel_name, Iridium.Services.Message message);
-    public signal void user_joined_channel (string server_name, string channel_name, string username);
-    public signal void user_left_channel (string server_name, string channel_name, string username);
-    public signal void private_message_received (string server_name, string username, string self_nickname, Iridium.Services.Message message);
+    public signal void user_joined_channel (string server_name, string channel_name, string nickname);
+    public signal void user_left_channel (string server_name, string channel_name, string nickname);
+    public signal void private_message_received (string server_name, string nickname, string self_nickname, Iridium.Services.Message message);
     public signal void insufficient_privs_received (string server_name, string channel_name, Iridium.Services.Message message);
     public signal void nickname_changed (string server_name, string old_nickname, string new_nickname);
     public signal void user_changed_nickname (string server_name, string old_nickname, string new_nickname);

--- a/src/Services/ServerConnectionRepository.vala
+++ b/src/Services/ServerConnectionRepository.vala
@@ -192,19 +192,19 @@ public class Iridium.Services.ServerConnectionRepository : GLib.Object {
         }
     }
 
-    public void on_private_message_row_added (string server_name, string username) {
+    public void on_private_message_row_added (string server_name, string nickname) {
         // TODO: Implement
     }
 
-    public void on_private_message_row_removed (string server_name, string username) {
+    public void on_private_message_row_removed (string server_name, string nickname) {
         // TODO: Implement
     }
 
-    public void on_private_message_row_enabled (string server_name, string username) {
+    public void on_private_message_row_enabled (string server_name, string nickname) {
         // TODO: Implement
     }
 
-    public void on_private_message_row_disabled (string server_name, string username) {
+    public void on_private_message_row_disabled (string server_name, string nickname) {
         // TODO: Implement
     }
 

--- a/src/Views/ChannelChatView.vala
+++ b/src/Views/ChannelChatView.vala
@@ -21,7 +21,7 @@
 
 public class Iridium.Views.ChannelChatView : Iridium.Views.ChatView {
 
-    private Gee.List<string> usernames = new Gee.ArrayList<string> ();
+    private Gee.List<string> nicknames = new Gee.ArrayList<string> ();
     private string? last_sender = null;
 
     public ChannelChatView (Iridium.MainWindow window, string nickname) {
@@ -41,10 +41,10 @@ public class Iridium.Views.ChannelChatView : Iridium.Views.ChatView {
 
     public override void do_display_self_private_msg (Iridium.Services.Message message) {
         var rich_text = new Iridium.Models.Text.SelfPrivateMessageText (message);
-        rich_text.set_usernames (usernames);
-        rich_text.suppress_sender_username = is_repeat_sender (message);
+        rich_text.set_nicknames (nicknames);
+        rich_text.suppress_sender_nickname = is_repeat_sender (message);
         rich_text.display (text_view.get_buffer ());
-        last_sender = message.username;
+        last_sender = message.nickname;
     }
 
     public override void do_display_server_msg (Iridium.Services.Message message) {
@@ -61,14 +61,14 @@ public class Iridium.Views.ChannelChatView : Iridium.Views.ChatView {
 
     public override void do_display_private_msg (Iridium.Services.Message message) {
         var rich_text = new Iridium.Models.Text.OthersPrivateMessageText (message);
-        rich_text.set_usernames (usernames);
-        rich_text.suppress_sender_username = is_repeat_sender (message);
+        rich_text.set_nicknames (nicknames);
+        rich_text.suppress_sender_nickname = is_repeat_sender (message);
         rich_text.display (text_view.get_buffer ());
-        last_sender = message.username;
+        last_sender = message.nickname;
     }
 
     private bool is_repeat_sender (Iridium.Services.Message message) {
-        return last_sender == message.username;
+        return last_sender == message.nickname;
     }
 
     //  public void display_channel_error_msg (Iridium.Services.Message message) {
@@ -78,8 +78,8 @@ public class Iridium.Views.ChannelChatView : Iridium.Views.ChatView {
     //      //  }
     //  }
 
-    public void set_usernames (Gee.List<string> usernames) {
-        this.usernames = usernames;
+    public void set_nicknames (Gee.List<string> nicknames) {
+        this.nicknames = nicknames;
     }
 
 }

--- a/src/Views/ChatView.vala
+++ b/src/Views/ChatView.vala
@@ -190,26 +190,26 @@ public abstract class Iridium.Views.ChatView : Gtk.Grid {
     private void create_text_tags () {
         var buffer = text_view.get_buffer ();
 
-        // Other usernames
-        unowned Gtk.TextTag username_tag = buffer.create_tag ("username");
-        username_tag.weight = Pango.Weight.SEMIBOLD;
-        username_tag.event.connect (on_username_clicked);
+        // Other nicknames
+        unowned Gtk.TextTag nickname_tag = buffer.create_tag ("nickname");
+        nickname_tag.weight = Pango.Weight.SEMIBOLD;
+        nickname_tag.event.connect (on_nickname_clicked);
 
-        // Self username
-        unowned Gtk.TextTag self_username_tag = buffer.create_tag ("self-username");
-        self_username_tag.weight = Pango.Weight.SEMIBOLD;
-        self_username_tag.event.connect (on_username_clicked);
+        // Self nickname
+        unowned Gtk.TextTag self_nickname_tag = buffer.create_tag ("self-nickname");
+        self_nickname_tag.weight = Pango.Weight.SEMIBOLD;
+        self_nickname_tag.event.connect (on_nickname_clicked);
 
         // Errors
         unowned Gtk.TextTag error_tag = buffer.create_tag ("error");
         error_tag.weight = Pango.Weight.SEMIBOLD;
 
-        // Inline usernames
-        unowned Gtk.TextTag inline_username_tag = buffer.create_tag ("inline-username");
-        inline_username_tag.event.connect (on_username_clicked);
+        // Inline nicknames
+        unowned Gtk.TextTag inline_nickname_tag = buffer.create_tag ("inline-nickname");
+        inline_nickname_tag.event.connect (on_nickname_clicked);
 
-        // Inline self username
-        buffer.create_tag ("inline-self-username");
+        // Inline self nickname
+        buffer.create_tag ("inline-self-nickname");
 
         // Selectable
         buffer.create_tag ("selectable");
@@ -229,25 +229,25 @@ public abstract class Iridium.Views.ChatView : Gtk.Grid {
         var tag_table = text_view.get_buffer ().get_tag_table ();
         var color = Gdk.RGBA ();
 
-        // Other usernames
+        // Other nicknames
         color.parse (Iridium.Models.ColorPalette.COLOR_BLUEBERRY.get_value ());
-        tag_table.lookup ("username").foreground_rgba = color;
+        tag_table.lookup ("nickname").foreground_rgba = color;
 
-        // Self username
+        // Self nickname
         color.parse (Iridium.Models.ColorPalette.COLOR_LIME.get_value ());
-        tag_table.lookup ("self-username").foreground_rgba = color;
+        tag_table.lookup ("self-nickname").foreground_rgba = color;
 
         // Errors
         color.parse (Iridium.Models.ColorPalette.COLOR_STRAWBERRY.get_value ());
         tag_table.lookup ("error").foreground_rgba = color;
 
-        // Inline usernames
+        // Inline nicknames
         color.parse (Iridium.Models.ColorPalette.COLOR_ORANGE.get_value ());
-        tag_table.lookup ("inline-username").foreground_rgba = color;
+        tag_table.lookup ("inline-nickname").foreground_rgba = color;
 
-        // Inline self username
+        // Inline self nickname
         color.parse (Iridium.Models.ColorPalette.COLOR_LIME.get_value ());
-        tag_table.lookup ("inline-self-username").foreground_rgba = color;
+        tag_table.lookup ("inline-self-nickname").foreground_rgba = color;
 
         // Hyperlinks
         color.parse (Iridium.Models.ColorPalette.COLOR_BLUEBERRY.get_value ());
@@ -299,19 +299,19 @@ public abstract class Iridium.Views.ChatView : Gtk.Grid {
         text_view.queue_draw ();
     }
 
-    private bool on_username_clicked (Gtk.TextTag source, GLib.Object event_object, Gdk.Event event, Gtk.TextIter iter) {
+    private bool on_nickname_clicked (Gtk.TextTag source, GLib.Object event_object, Gdk.Event event, Gtk.TextIter iter) {
         // TODO: Check for right click and show some options in a popup menu (eg. block, PM, etc.)
         if (event.type == Gdk.EventType.BUTTON_RELEASE) {
-            var username = get_selectable_text (iter);
-            if (username == null) {
-                warning ("Encountered click of null username");
+            var nickname = get_selectable_text (iter);
+            if (nickname == null) {
+                warning ("Encountered click of null nickname");
                 return false;
             }
             if (entry.text.length == 0) {
-                entry.text = username + ": ";
+                entry.text = nickname + ": ";
                 set_entry_focus ();
             } else {
-                entry.text += username;
+                entry.text += nickname;
                 set_entry_focus ();
             }
         }

--- a/src/Views/PrivateMessageChatView.vala
+++ b/src/Views/PrivateMessageChatView.vala
@@ -21,15 +21,15 @@
 
 public class Iridium.Views.PrivateMessageChatView : Iridium.Views.ChatView {
 
-    public string username { get; set; }
+    public string other_nickname { get; set; }
 
     private string last_sender = null;
 
-    public PrivateMessageChatView (Iridium.MainWindow window, string self_nickname, string username) {
+    public PrivateMessageChatView (Iridium.MainWindow window, string self_nickname, string other_nickname) {
         Object (
             window: window,
             nickname: self_nickname,
-            username: username
+            other_nickname: other_nickname
         );
     }
 
@@ -43,9 +43,9 @@ public class Iridium.Views.PrivateMessageChatView : Iridium.Views.ChatView {
 
     public override void do_display_self_private_msg (Iridium.Services.Message message) {
         var rich_text = new Iridium.Models.Text.SelfPrivateMessageText (message);
-        rich_text.suppress_sender_username = is_repeat_sender (message);
+        rich_text.suppress_sender_nickname = is_repeat_sender (message);
         rich_text.display (text_view.get_buffer ());
-        last_sender = message.username;
+        last_sender = message.nickname;
     }
 
     public override void do_display_server_msg (Iridium.Services.Message message) {
@@ -62,13 +62,13 @@ public class Iridium.Views.PrivateMessageChatView : Iridium.Views.ChatView {
 
     public override void do_display_private_msg (Iridium.Services.Message message) {
         var rich_text = new Iridium.Models.Text.OthersPrivateMessageText (message);
-        rich_text.suppress_sender_username = is_repeat_sender (message);
+        rich_text.suppress_sender_nickname = is_repeat_sender (message);
         rich_text.display (text_view.get_buffer ());
-        last_sender = message.username;
+        last_sender = message.nickname;
     }
 
     private bool is_repeat_sender (Iridium.Services.Message message) {
-        return last_sender == message.username;
+        return last_sender == message.nickname;
     }
 
 }

--- a/src/Widgets/Dialogs/ServerConnectionDialog.vala
+++ b/src/Widgets/Dialogs/ServerConnectionDialog.vala
@@ -23,7 +23,7 @@ public class Iridium.Widgets.ServerConnectionDialog : Gtk.Dialog {
 
     private Gtk.Entry server_entry;
     private Gtk.Entry nickname_entry;
-    private Gtk.Entry username_entry;
+    //  private Gtk.Entry username_entry;
     private Gtk.Entry realname_entry;
     private Gee.Map<int, Iridium.Models.AuthenticationMethod> auth_methods;
     private Gee.Map<int, string> auth_method_display_strings;
@@ -158,12 +158,12 @@ public class Iridium.Widgets.ServerConnectionDialog : Gtk.Dialog {
         nickname_entry.hexpand = true;
         nickname_entry.placeholder_text = "iridium";
 
-        var username_label = new Gtk.Label (_("Username:"));
-        username_label.halign = Gtk.Align.END;
+        //  var username_label = new Gtk.Label (_("Username:"));
+        //  username_label.halign = Gtk.Align.END;
 
-        username_entry = new Gtk.Entry ();
-        username_entry.hexpand = true;
-        username_entry.placeholder_text = "iridium";
+        //  username_entry = new Gtk.Entry ();
+        //  username_entry.hexpand = true;
+        //  username_entry.placeholder_text = "iridium";
 
         var realname_label = new Gtk.Label (_("Real Name:"));
         realname_label.halign = Gtk.Align.END;
@@ -223,14 +223,14 @@ public class Iridium.Widgets.ServerConnectionDialog : Gtk.Dialog {
         basic_form_grid.attach (server_entry, 1, 0, 1, 1);
         basic_form_grid.attach (nickname_label, 0, 1, 1, 1);
         basic_form_grid.attach (nickname_entry, 1, 1, 1, 1);
-        basic_form_grid.attach (username_label, 0, 2, 1, 1);
-        basic_form_grid.attach (username_entry, 1, 2, 1, 1);
-        basic_form_grid.attach (realname_label, 0, 3, 1, 1);
-        basic_form_grid.attach (realname_entry, 1, 3, 1, 1);
-        basic_form_grid.attach (auth_method_label, 0, 4, 1, 1);
-        basic_form_grid.attach (auth_method_combo, 1, 4, 1, 1);
-        basic_form_grid.attach (password_label, 0, 5, 1, 1);
-        basic_form_grid.attach (password_entry, 1, 5, 1, 1);
+        //  basic_form_grid.attach (username_label, 0, 2, 1, 1);
+        //  basic_form_grid.attach (username_entry, 1, 2, 1, 1);
+        basic_form_grid.attach (realname_label, 0, 2, 1, 1);
+        basic_form_grid.attach (realname_entry, 1, 2, 1, 1);
+        basic_form_grid.attach (auth_method_label, 0, 3, 1, 1);
+        basic_form_grid.attach (auth_method_combo, 1, 3, 1, 1);
+        basic_form_grid.attach (password_label, 0, 4, 1, 1);
+        basic_form_grid.attach (password_entry, 1, 4, 1, 1);
 
         return basic_form_grid;
     }
@@ -297,7 +297,7 @@ public class Iridium.Widgets.ServerConnectionDialog : Gtk.Dialog {
     private void load_settings () {
         on_security_posture_changed ();
         nickname_entry.text = Iridium.Application.settings.get_string ("default-nickname");
-        username_entry.text = Iridium.Application.settings.get_string ("default-nickname");
+        //  username_entry.text = Iridium.Application.settings.get_string ("default-nickname");
         realname_entry.text = Iridium.Application.settings.get_string ("default-realname");
     }
 
@@ -307,7 +307,7 @@ public class Iridium.Widgets.ServerConnectionDialog : Gtk.Dialog {
         status_label.label = "";
         var server_name = server_entry.get_text ().chomp ().chug ();
         var nickname = nickname_entry.get_text ().chomp ().chug ();
-        var username = username_entry.get_text ().chomp ().chug ();
+        //  var username = username_entry.get_text ().chomp ().chug ();
         var realname = realname_entry.get_text ().chomp ().chug ();
         var port = (uint16) int.parse (port_entry.get_text ().chomp ().chug ());
         if (port == 0) {
@@ -316,7 +316,7 @@ public class Iridium.Widgets.ServerConnectionDialog : Gtk.Dialog {
         var auth_method = auth_methods.get (auth_method_combo.get_active ());
         var auth_token = password_entry.get_text ();
         var tls = ssl_tls_switch.get_active ();
-        connect_button_clicked (server_name, nickname, username, realname, port, auth_method, tls, auth_token);
+        connect_button_clicked (server_name, nickname, realname, port, auth_method, tls, auth_token);
     }
 
     public string get_server () {
@@ -334,7 +334,7 @@ public class Iridium.Widgets.ServerConnectionDialog : Gtk.Dialog {
         status_label.label = message;
     }
 
-    public signal void connect_button_clicked (string server, string nickname, string username, string realname,
+    public signal void connect_button_clicked (string server, string nickname, string realname,
         uint16 port, Iridium.Models.AuthenticationMethod auth_method, bool tls, string auth_token);
 
 }

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -80,7 +80,7 @@ public class Iridium.Widgets.HeaderBar : Gtk.HeaderBar {
         channel_users_button.valign = Gtk.Align.CENTER;
 
         channel_users_popover = new Iridium.Widgets.UsersPopover.ChannelUsersPopover (channel_users_button);
-        channel_users_popover.username_selected.connect (on_username_selected);
+        channel_users_popover.nickname_selected.connect (on_nickname_selected);
         channel_users_button.popover = channel_users_popover;
 
         var settings_button = new Gtk.MenuButton ();
@@ -184,14 +184,14 @@ public class Iridium.Widgets.HeaderBar : Gtk.HeaderBar {
         channel_users_button.sensitive = enabled;
     }
 
-    public void set_channel_users (Gee.List<string> usernames) {
-        channel_users_popover.set_users (usernames);
+    public void set_channel_users (Gee.List<string> nicknames) {
+        channel_users_popover.set_users (nicknames);
     }
 
-    private void on_username_selected (string username) {
-        username_selected (username);
+    private void on_nickname_selected (string nickname) {
+        nickname_selected (nickname);
     }
 
-    public signal void username_selected (string username);
+    public signal void nickname_selected (string nickname);
 
 }

--- a/src/Widgets/SidePanel/Panel.vala
+++ b/src/Widgets/SidePanel/Panel.vala
@@ -266,19 +266,19 @@ public class Iridium.Widgets.SidePanel.Panel : Gtk.Grid {
 
     // TODO: Lots of refactoring can be done here. Lots of code is shared
     //       with the channel functions!
-    public void add_private_message_row (string server_name, string username) {
+    public void add_private_message_row (string server_name, string nickname) {
         // Check if this private message row already exists
         var server_item = server_items.get (server_name);
         foreach (var child in server_item.children) {
             if (child is Iridium.Widgets.SidePanel.PrivateMessageRow) {
                 unowned Iridium.Widgets.SidePanel.PrivateMessageRow private_message_item = (Iridium.Widgets.SidePanel.PrivateMessageRow) child;
-                if (private_message_item.username == username) {
+                if (private_message_item.nickname == nickname) {
                     return;
                 }
             }
         }
 
-        var private_message_item = new Iridium.Widgets.SidePanel.PrivateMessageRow (username, server_name);
+        var private_message_item = new Iridium.Widgets.SidePanel.PrivateMessageRow (nickname, server_name);
         private_message_item.close_private_message.connect (() => {
             remove_private_message_row (server_name, private_message_item.get_channel_name ());
         });
@@ -288,12 +288,12 @@ public class Iridium.Widgets.SidePanel.Panel : Gtk.Grid {
         private_message_items.get (server_name).add (private_message_item);
     }
 
-    private void remove_private_message_row (string server_name, string username) {
+    private void remove_private_message_row (string server_name, string nickname) {
         var server_item = server_items.get (server_name);
         foreach (var child in server_item.children) {
             if (child is Iridium.Widgets.SidePanel.PrivateMessageRow) {
                 unowned Iridium.Widgets.SidePanel.PrivateMessageRow private_message_row = (Iridium.Widgets.SidePanel.PrivateMessageRow) child;
-                if (private_message_row.get_channel_name () == username) {
+                if (private_message_row.get_channel_name () == nickname) {
                     server_item.remove (child);
                     private_message_items.get (server_name).remove (private_message_row);
                     return;
@@ -426,7 +426,7 @@ public class Iridium.Widgets.SidePanel.Panel : Gtk.Grid {
         }
     }
 
-    public void select_private_message_row (string server_name, string username) {
+    public void select_private_message_row (string server_name, string nickname) {
         var server_item = server_items.get (server_name);
         if (server_item == null) {
             return;
@@ -435,7 +435,7 @@ public class Iridium.Widgets.SidePanel.Panel : Gtk.Grid {
             // TODO: Apply this type check in other places
             if (channel_item is Iridium.Widgets.SidePanel.PrivateMessageRow) {
                 unowned Iridium.Widgets.SidePanel.PrivateMessageRow row = (Iridium.Widgets.SidePanel.PrivateMessageRow) channel_item;
-                if (row.get_channel_name () == username) {
+                if (row.get_channel_name () == nickname) {
                     source_list.selected = channel_item;
                     return;
                 }
@@ -504,8 +504,8 @@ public class Iridium.Widgets.SidePanel.Panel : Gtk.Grid {
         foreach (var child in server_item.children) {
             if (child is Iridium.Widgets.SidePanel.PrivateMessageRow) {
                 unowned Iridium.Widgets.SidePanel.PrivateMessageRow private_message_item = (Iridium.Widgets.SidePanel.PrivateMessageRow) child;
-                if (private_message_item.username == old_nickname) {
-                    private_message_item.set_nickname (new_nickname);
+                if (private_message_item.nickname == old_nickname) {
+                    private_message_item.update_nickname (new_nickname);
                 }
             }
         }
@@ -561,9 +561,9 @@ public class Iridium.Widgets.SidePanel.Panel : Gtk.Grid {
     public signal void channel_row_removed (string server_name, string channel_name);
     public signal void channel_row_enabled (string server_name, string channel_name);
     public signal void channel_row_disabled (string server_name, string channel_name);
-    public signal void private_message_row_added (string server_name, string username);
-    public signal void private_message_row_removed (string server_name, string username);
-    public signal void private_message_row_enabled (string server_name, string username);
-    public signal void private_message_row_disabled (string server_name, string username);
+    public signal void private_message_row_added (string server_name, string nickname);
+    public signal void private_message_row_removed (string server_name, string nickname);
+    public signal void private_message_row_enabled (string server_name, string nickname);
+    public signal void private_message_row_disabled (string server_name, string nickname);
 
 }

--- a/src/Widgets/SidePanel/PrivateMessageRow.vala
+++ b/src/Widgets/SidePanel/PrivateMessageRow.vala
@@ -21,16 +21,16 @@
 
 public class Iridium.Widgets.SidePanel.PrivateMessageRow : Granite.Widgets.SourceList.ExpandableItem, Iridium.Widgets.SidePanel.Row {
 
-    public string username { get; set; }
+    public string nickname { get; set; }
     public string server_name { get; construct; }
     public Iridium.Widgets.SidePanel.Row.State state { get; set; }
 
     private bool is_enabled = true;
 
-    public PrivateMessageRow (string username, string server_name) {
+    public PrivateMessageRow (string nickname, string server_name) {
         Object (
-            name: username,
-            username: username,
+            name: nickname,
+            nickname: nickname,
             server_name: server_name,
             icon: new GLib.ThemedIcon ("system-users"),
             state: Iridium.Widgets.SidePanel.Row.State.DISABLED
@@ -42,7 +42,7 @@ public class Iridium.Widgets.SidePanel.PrivateMessageRow : Granite.Widgets.Sourc
     }
 
     public new string? get_channel_name () {
-        return username;
+        return nickname;
     }
 
     public new void enable () {
@@ -60,7 +60,7 @@ public class Iridium.Widgets.SidePanel.PrivateMessageRow : Granite.Widgets.Sourc
             return;
         }
         //  icon = new GLib.ThemedIcon ("user-offline");
-        markup = "<i>" + username + "</i>";
+        markup = "<i>" + nickname + "</i>";
         is_enabled = false;
     }
 
@@ -70,7 +70,7 @@ public class Iridium.Widgets.SidePanel.PrivateMessageRow : Granite.Widgets.Sourc
     public new void updating () {
         //  icon = new GLib.ThemedIcon ("mail-unread");
         icon = new GLib.ThemedIcon (Constants.APP_ID + ".image-loading-symbolic");
-        markup = "<i>" + username + "</i>";
+        markup = "<i>" + nickname + "</i>";
         is_enabled = false;
     }
 
@@ -92,9 +92,9 @@ public class Iridium.Widgets.SidePanel.PrivateMessageRow : Granite.Widgets.Sourc
         return menu;
     }
 
-    public void set_nickname (string nickname) {
+    public void update_nickname (string nickname) {
         this.name = nickname;
-        this.username = nickname;
+        this.nickname = nickname;
     }
 
     public signal void close_private_message ();

--- a/src/Widgets/SidePanel/ServerRow.vala
+++ b/src/Widgets/SidePanel/ServerRow.vala
@@ -85,7 +85,7 @@ public class Iridium.Widgets.SidePanel.ServerRow : Granite.Widgets.SourceList.Ex
         } else if (a is Iridium.Widgets.SidePanel.PrivateMessageRow && b is Iridium.Widgets.SidePanel.PrivateMessageRow) {
             var pm_a = a as Iridium.Widgets.SidePanel.PrivateMessageRow;
             var pm_b = b as Iridium.Widgets.SidePanel.PrivateMessageRow;
-            return pm_a.username.ascii_casecmp (pm_b.username);
+            return pm_a.nickname.ascii_casecmp (pm_b.nickname);
         } else {
             // TODO: Log this undefined behavior that should never happen
             return 0;

--- a/src/Widgets/UsersPopover/ChannelUsersPopover.vala
+++ b/src/Widgets/UsersPopover/ChannelUsersPopover.vala
@@ -21,8 +21,8 @@
 
 public class Iridium.Widgets.UsersPopover.ChannelUsersPopover : Gtk.Popover {
 
-    // TODO: Need to handle usernames for OPs and other special cases where the
-    //       username starts with a symbol (e.g. @)
+    // TODO: Need to handle nicknames for OPs and other special cases where the
+    //       nickname starts with a symbol (e.g. @)
 
     private Gtk.SearchEntry search_entry;
     private Gtk.ScrolledWindow scrolled_window;
@@ -75,7 +75,7 @@ public class Iridium.Widgets.UsersPopover.ChannelUsersPopover : Gtk.Popover {
                 return;
             }
             Iridium.Widgets.UsersPopover.UserListBoxRow user_row = (Iridium.Widgets.UsersPopover.UserListBoxRow) row;
-            username_selected (user_row.username);
+            nickname_selected (user_row.nickname);
             popdown ();
         });
         this.closed.connect (() => {
@@ -89,24 +89,24 @@ public class Iridium.Widgets.UsersPopover.ChannelUsersPopover : Gtk.Popover {
             return true;
         }
         Iridium.Widgets.UsersPopover.UserListBoxRow user_row = (Iridium.Widgets.UsersPopover.UserListBoxRow) row;
-        return user_row.username.contains (search_entry.text);
+        return user_row.nickname.contains (search_entry.text);
     }
 
     private int sort_func (Gtk.ListBoxRow row1, Gtk.ListBoxRow row2) {
         Iridium.Widgets.UsersPopover.UserListBoxRow user_row1 = (Iridium.Widgets.UsersPopover.UserListBoxRow) row1;
         Iridium.Widgets.UsersPopover.UserListBoxRow user_row2 = (Iridium.Widgets.UsersPopover.UserListBoxRow) row2;
-        return user_row1.username.collate (user_row2.username);
+        return user_row1.nickname.collate (user_row2.nickname);
     }
 
-    public void set_users (Gee.List<string> usernames) {
+    public void set_users (Gee.List<string> nicknames) {
         list_box.foreach ((widget) => {
             widget.destroy ();
         });
-        foreach (string username in usernames) {
-            if (username == null || username.chomp ().length == 0) {
+        foreach (string nickname in nicknames) {
+            if (nickname == null || nickname.chomp ().length == 0) {
                 continue;
             }
-            var row = new Iridium.Widgets.UsersPopover.UserListBoxRow (username);
+            var row = new Iridium.Widgets.UsersPopover.UserListBoxRow (nickname);
             list_box.insert (row, -1);
         }
         list_box.show_all ();
@@ -115,6 +115,6 @@ public class Iridium.Widgets.UsersPopover.ChannelUsersPopover : Gtk.Popover {
         scrolled_window.check_resize ();
     }
 
-    public signal void username_selected (string username);
+    public signal void nickname_selected (string nickname);
 
 }

--- a/src/Widgets/UsersPopover/UserListBoxRow.vala
+++ b/src/Widgets/UsersPopover/UserListBoxRow.vala
@@ -21,13 +21,13 @@
 
 public class Iridium.Widgets.UsersPopover.UserListBoxRow : Gtk.ListBoxRow {
 
-    public string username { get; construct; }
+    public string nickname { get; construct; }
 
     private Gtk.EventBox event_box;
 
-    public UserListBoxRow (string username) {
+    public UserListBoxRow (string nickname) {
         Object (
-            username: username
+            nickname: nickname
         );
     }
 
@@ -42,7 +42,7 @@ public class Iridium.Widgets.UsersPopover.UserListBoxRow : Gtk.ListBoxRow {
             return false;
         });
 
-        var label = new Gtk.Label (username);
+        var label = new Gtk.Label (nickname);
         label.margin_top = 4;
         label.margin_bottom = 4;
 


### PR DESCRIPTION
Using nickname throughout instead of both nickname and username. Username still used where appropriate. Also hiding username from the connection dialog because it's not completely necessary. Will use nickname as both nick and username.

Fixes #50 