### PR TITLE
Handle nickname-in-use better when reconnecting

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -863,6 +863,7 @@ public class Iridium.MainWindow : Gtk.ApplicationWindow {
             var chat_view = main_layout.get_server_chat_view (server_name);
             chat_view.display_server_error_msg (message);
             // TODO: Prompt for new nickname?
+            Iridium.Application.connection_manager.fail_server_connection (server_name, _("Nickname already in use"), _("Choose a new nickname and retry the connection."));
         }
     }
 

--- a/src/Services/ServerConnectionManager.vala
+++ b/src/Services/ServerConnectionManager.vala
@@ -89,6 +89,16 @@ public class Iridium.Services.ServerConnectionManager : GLib.Object {
         open_connections.unset (server);
     }
 
+    public void fail_server_connection (string server, string error_message, string? error_details) {
+        var connection = open_connections.get (server);
+        if (connection == null) {
+            return;
+        }
+        connection.close ();
+        open_connections.unset (server);
+        connection.open_failed (error_message, error_details);
+    }
+
     public Iridium.Services.ServerConnectionDetails? get_connection_details (string server_name) {
         var connection = open_connections.get (server_name);
         if (connection == null) {


### PR DESCRIPTION
Fix #109 