### PR TITLE
Add datetime label to chat views after 15min

### DIFF
--- a/src/Models/Text/DateTimeMessageText.vala
+++ b/src/Models/Text/DateTimeMessageText.vala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021 Andrew Vojak (https://avojak.com)
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA
+ *
+ * Authored by: Andrew Vojak <andrew.vojak@gmail.com>
+ */
+
+public class Iridium.Models.Text.DateTimeMessageText : Iridium.Models.Text.RichText {
+
+    public DateTimeMessageText (Iridium.Services.Message message) {
+        Object (
+            message: message
+        );
+    }
+
+    public override void do_display (Gtk.TextBuffer buffer) {
+        Gtk.TextIter iter;
+        buffer.get_end_iter (out iter);
+        buffer.insert (ref iter, message.message, message.message.length);
+
+        // Format the message
+        Gtk.TextIter start = iter;
+        start.backward_chars (message.message.length);
+        buffer.apply_tag_by_name ("datetime", start, iter);
+
+        buffer.insert (ref iter, "\n", 1);
+    }
+
+}

--- a/src/Views/ChannelChatView.vala
+++ b/src/Views/ChannelChatView.vala
@@ -22,7 +22,6 @@
 public class Iridium.Views.ChannelChatView : Iridium.Views.ChatView {
 
     private Gee.List<string> nicknames = new Gee.ArrayList<string> ();
-    private string? last_sender = null;
 
     public ChannelChatView (Iridium.MainWindow window, string nickname) {
         Object (
@@ -65,6 +64,10 @@ public class Iridium.Views.ChannelChatView : Iridium.Views.ChatView {
         rich_text.suppress_sender_nickname = is_repeat_sender (message);
         rich_text.display (text_view.get_buffer ());
         last_sender = message.nickname;
+    }
+
+    public override bool does_display_datetime () {
+        return true;
     }
 
     private bool is_repeat_sender (Iridium.Services.Message message) {

--- a/src/Views/PrivateMessageChatView.vala
+++ b/src/Views/PrivateMessageChatView.vala
@@ -23,8 +23,6 @@ public class Iridium.Views.PrivateMessageChatView : Iridium.Views.ChatView {
 
     public string other_nickname { get; set; }
 
-    private string? last_sender = null;
-
     public PrivateMessageChatView (Iridium.MainWindow window, string self_nickname, string other_nickname) {
         Object (
             window: window,
@@ -65,6 +63,10 @@ public class Iridium.Views.PrivateMessageChatView : Iridium.Views.ChatView {
         rich_text.suppress_sender_nickname = is_repeat_sender (message);
         rich_text.display (text_view.get_buffer ());
         last_sender = message.nickname;
+    }
+
+    public override bool does_display_datetime () {
+        return true;
     }
 
     private bool is_repeat_sender (Iridium.Services.Message message) {

--- a/src/Views/ServerChatView.vala
+++ b/src/Views/ServerChatView.vala
@@ -55,4 +55,8 @@ public class Iridium.Views.ServerChatView : Iridium.Views.ChatView {
         // Do nothing
     }
 
+    public override bool does_display_datetime () {
+        return false;
+    }
+
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -29,6 +29,7 @@ iridium_files = files(
     join_paths('Models', 'NumericCodes.vala'),
     join_paths('Models', 'Text', 'RichText.vala'),
     join_paths('Models', 'Text', 'ChannelErrorMessageText.vala'),
+    join_paths('Models', 'Text', 'DateTimeMessageText.vala'),
     join_paths('Models', 'Text', 'PrivateMessageText.vala'),
     join_paths('Models', 'Text', 'SelfPrivateMessageText.vala'),
     join_paths('Models', 'Text', 'OthersPrivateMessageText.vala'),


### PR DESCRIPTION
If 15 or more minutes have passed between messages, a datetime label appears in the chat view.
![datetime](https://user-images.githubusercontent.com/3663899/106390659-ac37ef80-63a6-11eb-82eb-277fe8104613.png)

Resolves #21 
