### PR TITLE
Allow suppressing join/part messages

### DIFF
--- a/data/com.github.avojak.iridium.gschema.xml.in
+++ b/data/com.github.avojak.iridium.gschema.xml.in
@@ -31,6 +31,11 @@
       <summary>If server connections should be remembered between sessions</summary>
       <description>If server connections should be remembered between sessions</description>
     </key>
+    <key name="suppress-join-part-messages" type="b">
+      <default>false</default>
+      <summary>If channel join and part messages should be suppressed</summary>
+      <description>If channel join and part messages should be suppressed</description>
+    </key>
     <key name="pos-x" type="i">
 			<default>360</default>
 			<summary>The saved horizontal position of the window.</summary>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1030,24 +1030,28 @@ public class Iridium.MainWindow : Gtk.ApplicationWindow {
     }
 
     private void on_user_joined_channel (string server_name, string channel_name, string nickname) {
-        Idle.add (() => {
-            // Display a message in the channel chat view
-            var message = new Iridium.Services.Message ();
-            message.message = nickname + _(" has joined");
-            main_layout.display_server_message (server_name, channel_name, message);
-            return false;
-        });
+        if (!Iridium.Application.settings.get_boolean ("suppress-join-part-messages")) {
+            Idle.add (() => {
+                // Display a message in the channel chat view
+                var message = new Iridium.Services.Message ();
+                message.message = nickname + _(" has joined");
+                main_layout.display_server_message (server_name, channel_name, message);
+                return false;
+            });
+        }
         update_channel_users_list (server_name, channel_name);
     }
 
     private void on_user_left_channel (string server_name, string channel_name, string nickname) {
-        Idle.add (() => {
-            // Display a message in the channel chat view
-            var message = new Iridium.Services.Message ();
-            message.message = nickname + _(" has left");
-            main_layout.display_server_message (server_name, channel_name, message);
-            return false;
-        });
+        if (!Iridium.Application.settings.get_boolean ("suppress-join-part-messages")) {
+            Idle.add (() => {
+                // Display a message in the channel chat view
+                var message = new Iridium.Services.Message ();
+                message.message = nickname + _(" has left");
+                main_layout.display_server_message (server_name, channel_name, message);
+                return false;
+            });
+        }
         update_channel_users_list (server_name, channel_name);
     }
 

--- a/src/Widgets/Dialogs/PreferencesDialog.vala
+++ b/src/Widgets/Dialogs/PreferencesDialog.vala
@@ -99,6 +99,13 @@ public class Iridium.Widgets.PreferencesDialog : Gtk.Dialog {
             Iridium.Application.settings.set_string ("default-realname", default_realname_entry.text.chomp ().chug ());
         });
 
+        var suppress_join_part_label = new Gtk.Label (_("Suppress join/part messages:"));
+        suppress_join_part_label.halign = Gtk.Align.END;
+        var suppress_join_part_switch = new Gtk.Switch ();
+        suppress_join_part_switch.halign = Gtk.Align.START;
+        suppress_join_part_switch.valign = Gtk.Align.CENTER;
+        Iridium.Application.settings.bind ("suppress-join-part-messages", suppress_join_part_switch, "active", SettingsBindFlags.DEFAULT);
+
         var security_header_label = new Granite.HeaderLabel (_("Security and Privacy"));
 
         var cert_validation_policy_label = new Gtk.Label (_("Unacceptable SSL/TLS Certificates:"));
@@ -196,6 +203,7 @@ public class Iridium.Widgets.PreferencesDialog : Gtk.Dialog {
         security_posture_stack.show_all (); // Required in order to set the visible child from preferences
 
         var remember_connections_label = new Gtk.Label (_("Remember connections between sessions:"));
+        remember_connections_label.halign = Gtk.Align.END;
         var remember_connections_switch = new Gtk.Switch ();
         remember_connections_switch.halign = Gtk.Align.START;
         remember_connections_switch.valign = Gtk.Align.CENTER;
@@ -222,12 +230,14 @@ public class Iridium.Widgets.PreferencesDialog : Gtk.Dialog {
         form_grid.attach (default_nickname_entry, 1, 1, 1);
         form_grid.attach (default_realname_label, 0, 2, 1);
         form_grid.attach (default_realname_entry, 1, 2, 1);
-        form_grid.attach (security_header_label, 0, 3, 1);
-        form_grid.attach (cert_validation_policy_label, 0, 4, 1);
-        form_grid.attach (cert_validation_policy_combo, 1, 4, 1);
-        form_grid.attach (security_posture_stack, 0, 5, 2);
-        form_grid.attach (remember_connections_label, 0, 6, 1);
-        form_grid.attach (remember_connections_switch, 1, 6, 1);
+        form_grid.attach (suppress_join_part_label, 0, 3, 1);
+        form_grid.attach (suppress_join_part_switch, 1, 3, 1);
+        form_grid.attach (security_header_label, 0, 4, 1);
+        form_grid.attach (cert_validation_policy_label, 0, 5, 1);
+        form_grid.attach (cert_validation_policy_combo, 1, 5, 1);
+        form_grid.attach (security_posture_stack, 0, 6, 2);
+        form_grid.attach (remember_connections_label, 0, 7, 1);
+        form_grid.attach (remember_connections_switch, 1, 7, 1);
 
         body.add (header_grid);
         body.add (form_grid);


### PR DESCRIPTION
Suppressing of messages if a global setting, not a per-channel or per-server basis.

Resolves #20 