### PR TITLE
added fedora support in install-dev-dependencies

### DIFF
--- a/install-dev-dependencies.sh
+++ b/install-dev-dependencies.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
-sudo apt install meson elementary-sdk
-
-sudo apt install libsecret-1-dev libsqlite3-dev libgtksourceview-4-dev libsoup2.4-dev libhandy-1-dev
+echo "installing dependencies for iridium"
+if (whiptail --title "Choose distro" --yesno "What distro are you using?" 8 78 --no-button "Fedora Based" --yes-button "Ubuntu or Debian based"); then
+  sudo apt install libsecret-1-dev libsqlite3-dev libgtksourceview-4-dev libsoup2.4-dev libhandy-1-dev && sudo apt install meson elementary-sdk
+else
+  sudo dnf install granite debhelper meson vala cmake gtk3-devel libgee-devel granite-devel libsecret-devel sqlite-devel gtksourceview4-devel libsoup-devel libhandy-devel
+fi


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/83690012/224519009-55c3c42b-40aa-403b-aa36-0527fac50ab3.png)
![image](https://user-images.githubusercontent.com/83690012/224519108-00727278-4e5d-4d32-b789-5a3cec29d1df.png)

as the packages are named differently on fedora, so it makes the process of installing iridium a bit simpler, rather than having to hunt for dependency packages, (ignored packages already preinstalled on fedora)

whiptail is also already included in debian/fedora based systems

also, are you planning to submit the flatpak build to flathub? currently the only way to install iridium on non-elementary os distros is to build from source